### PR TITLE
guinnesss gem 업데이트 관련해서 오류 수정이 필요합니다.

### DIFF
--- a/lib/coaster/core_ext/object_translation.rb
+++ b/lib/coaster/core_ext/object_translation.rb
@@ -49,6 +49,7 @@ class Object
           throw :exception, result if options[:original_throw]
           missing = options[:original_missing] || result
           msg = missing.message
+          msg = msg.dup
           msg.instance_variable_set(:@missing, missing)
           msg.instance_variable_set(:@tkey, options[:tkey])
           msg


### PR DESCRIPTION
51라인에서 I18n::MissingTranslation  message를 받아올 때가 있는데, gem 업데이트하면서 이 messeage가 freeze된 스트링으로 넘어옵니다. 따라서 메시지를 일단 duplication하도록 코드를 추가하였습니다.