### PR TITLE
:wrench: Insert digest_backtrace to fingerprint after initialize

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coaster (1.4.22)
+    coaster (1.4.24)
       activesupport (>= 7.0.7)
       attr_extras (~> 5.2)
       i18n (>= 1.0)
@@ -137,7 +137,7 @@ GEM
     nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    oj (3.16.7)
+    oj (3.16.9)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     ostruct (0.6.1)

--- a/lib/coaster/core_ext/standard_error.rb
+++ b/lib/coaster/core_ext/standard_error.rb
@@ -63,7 +63,8 @@ class StandardError
     end
   end
 
-  attr_accessor :tags, :level, :tkey, :fingerprint
+  attr_accessor :tags, :level, :tkey
+  attr_writer :fingerprint
 
   def initialize(message = nil, cause = $!)
     @fingerprint = Coaster.default_fingerprint.dup
@@ -122,11 +123,12 @@ class StandardError
     @digest_message = self.class.digest_message(msg)
     set_backtrace(message.backtrace) if message.is_a?(Exception)
     @fingerprint << @digest_message
-    @fingerprint << digest_backtrace
     @fingerprint.compact!
     self
   end
 
+  # @return [Array, NilClass] fingerprint
+  def fingerprint; @fingerprint.is_a?(Array) && @fingerprint + [digest_backtrace] end
   def safe_message; message || '' end
   def digest_message; @digest_message ||= self.class.digest_message(message) end
   def digest_backtrace; @digest_backtrace ||= backtrace ? Digest::MD5.hexdigest(cleaned_backtrace.join("\n"))[0...8] : nil end

--- a/lib/coaster/core_ext/standard_error.rb
+++ b/lib/coaster/core_ext/standard_error.rb
@@ -234,6 +234,7 @@ class StandardError
       http_status: http_status, message: message,
       instance_variables: {}.with_indifferent_access
     )
+    digest_backtrace # for @digest_backtrace
     instance_variables.sort.each do |var|
       if inspection_vars.include?(var)
         val = instance_variable_get(var)

--- a/lib/coaster/version.rb
+++ b/lib/coaster/version.rb
@@ -1,3 +1,3 @@
 module Coaster
-  VERSION = '1.4.24'
+  VERSION = '1.4.25'
 end

--- a/lib/coaster/version.rb
+++ b/lib/coaster/version.rb
@@ -1,3 +1,3 @@
 module Coaster
-  VERSION = '1.4.23'
+  VERSION = '1.4.24'
 end

--- a/test/test_standard_error.rb
+++ b/test/test_standard_error.rb
@@ -213,7 +213,7 @@ module Coaster
   MESSAGE: Test example error (Coaster::TestStandardError::ExampleError) cause{Test sample error (Coaster::TestStandardError::SampleError)}
   @attributes: {\"frog\"=>\"rams\", \"wat\"=>\"cha\"}
   @coaster: true
-  @digest_backtrace: NilClass
+  @digest_backtrace: #{e.digest_backtrace}
   @digest_message: a8c7c1
   @fingerprint: ["a8c7c1"]
   @ins_var: [\"Coaster::TestStandardError::SampleError\", {\"h\"=>1}]
@@ -231,7 +231,7 @@ CAUSE: [Coaster::TestStandardError::SampleError] status:10
     MESSAGE: Test sample error (Coaster::TestStandardError::SampleError)
     @attributes: {"frog"=>"rams"}
     @coaster: true
-    @digest_backtrace: NilClass
+    @digest_backtrace: #{e.cause.digest_backtrace}
     @digest_message: cbe233
     @fingerprint: ["cbe233"]
     @level: "error"


### PR DESCRIPTION
### 개요
- rails 7.1부터 ActionView::Template::Error에 [backtrace 메소드](https://github.com/rails/rails/blob/14c115b120ed089331ff3dc13f36bd9129ced33d/actionview/lib/action_view/template/error.rb#L171-L173)가 생김. 이로 인해 initialize에 backtrace 메소드를 호출하는 digest_backtrace가 문제가 되어 이렇게 수정함