### PR TITLE
:tada: Initialize ActionView::Template::Error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coaster (1.4.25)
+    coaster (1.4.27)
       activesupport (>= 7.0.7)
       attr_extras (~> 5.2)
       i18n (>= 1.0)
@@ -137,7 +137,7 @@ GEM
     nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    oj (3.16.9)
+    oj (3.16.10)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     ostruct (0.6.1)

--- a/lib/coaster/rails_ext.rb
+++ b/lib/coaster/rails_ext.rb
@@ -2,3 +2,6 @@ require 'coaster/rails_ext/active_support/backtrace_cleaner'
 ActiveSupport.on_load(:active_record, yield: true) do
   require 'coaster/rails_ext/active_record/errors'
 end
+ActiveSupport.on_load(:action_view, yield: true) do
+  require "coaster/rails_ext/action_view/template/error"
+end

--- a/lib/coaster/rails_ext/action_view/template/error.rb
+++ b/lib/coaster/rails_ext/action_view/template/error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ActionView
+  class Template
+    class Error < ActionViewError
+      # @return [Integer]
+      def http_status
+        cause.respond_to?(:http_status) ? cause.http_status : super
+      end
+    end
+  end
+end

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -2,7 +2,7 @@ require 'coaster/serialized_properties'
 require 'coaster/safe_yaml_serializer'
 
 class User < ActiveRecord::Base
-  serialize :data, Coaster::SafeYamlSerializer
+  serialize :data, coder: Coaster::SafeYamlSerializer
   extend Coaster::SerializedProperties
   serialized_column :data
   serialized_property :data, :appendix, default: {}

--- a/test/test_action_view.rb
+++ b/test/test_action_view.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "test_helper"
+require "action_view"
+require "coaster/rails_ext/action_view/template/error"
+
+module Coaster
+  class BadRequest < StandardError
+    def self.http_status = 400
+  end
+
+  class TestActionView < Minitest::Test
+    def test_http_status
+      begin
+        raise BadRequest
+      rescue BadRequest => e
+        template = ActionView::Template.new("Hello, World!", "test", ActionView::Template::Handlers::Raw, locals: [])
+        err = ActionView::Template::Error.new(template)
+
+        assert_equal err.cause, e
+        assert_equal err.http_status, e.http_status
+        assert_equal err.http_status, 400
+      end
+    end
+  end
+end


### PR DESCRIPTION
### 개요
- ActionView::Template::Error#http_status 메소드 추가
  - view 단에서 발생한 에러는 위 클래스로 wrap 되는데 그때 http_status가 의도한 값으로 내려보내기 위해 추가함