### PR TITLE
serialized_property setter의 불필요한 dirty marking 수정

### DIFF
--- a/test/test_serialized_property.rb
+++ b/test/test_serialized_property.rb
@@ -372,5 +372,113 @@ module Coaster
       assert_nil student.encrypted_value
       assert_nil student.data['encrypted_value']
     end
+
+    # Tests for dirty tracking optimization (skip dirty marking when value unchanged)
+    def test_same_value_setter_does_not_mark_dirty
+      user = User.create(name: 'test_same_value')
+      user.simple = 'initial_value'
+      user.save!
+
+      # Reload to clear dirty state
+      user.reload
+      assert_equal false, user.changed?
+
+      # Set same value - should NOT mark dirty
+      user.simple = 'initial_value'
+      assert_equal false, user.simple_changed?, 'Setting same value should not mark property as changed'
+      assert_equal false, user.changed?, 'Setting same value should not mark record as changed'
+    end
+
+    def test_different_value_setter_marks_dirty
+      user = User.create(name: 'test_different_value')
+      user.simple = 'initial_value'
+      user.save!
+      user.reload
+
+      # Set different value - should mark dirty
+      user.simple = 'new_value'
+      assert_equal true, user.simple_changed?, 'Setting different value should mark property as changed'
+      assert_equal true, user.changed?, 'Setting different value should mark record as changed'
+      assert_equal ['initial_value', 'new_value'], user.simple_change
+    end
+
+    def test_nil_to_value_marks_dirty
+      user = User.create(name: 'test_nil_to_value')
+      user.save!
+      user.reload
+
+      assert_nil user.simple
+      user.simple = 'some_value'
+      assert_equal true, user.simple_changed?
+      assert_equal [nil, 'some_value'], user.simple_change
+    end
+
+    def test_value_to_nil_marks_dirty
+      user = User.create(name: 'test_value_to_nil')
+      user.simple = 'some_value'
+      user.save!
+      user.reload
+
+      user.simple = nil
+      assert_equal true, user.simple_changed?
+      assert_equal ['some_value', nil], user.simple_change
+    end
+
+    def test_nil_to_nil_does_not_mark_dirty
+      user = User.create(name: 'test_nil_to_nil')
+      user.save!
+      user.reload
+
+      assert_nil user.simple
+      user.simple = nil
+      assert_equal false, user.simple_changed?, 'Setting nil to nil should not mark as changed'
+      assert_equal false, user.changed?
+    end
+
+    def test_same_value_via_write_attribute_does_not_mark_dirty
+      user = User.create(name: 'test_write_attr_same')
+      user.write_attribute(:simple, 'initial')
+      user.save!
+      user.reload
+
+      user.write_attribute(:simple, 'initial')
+      assert_equal false, user.simple_changed?
+      assert_equal false, user.changed?
+    end
+
+    def test_same_value_via_bracket_accessor_does_not_mark_dirty
+      user = User.create(name: 'test_bracket_same')
+      user[:simple] = 'initial'
+      user.save!
+      user.reload
+
+      user[:simple] = 'initial'
+      assert_equal false, user.simple_changed?
+      assert_equal false, user.changed?
+    end
+
+    def test_same_value_with_setter_proc_does_not_mark_dirty
+      student = Student.create(name: 'test_setter_same')
+      student.uppercase_name = 'hello'  # Stored as 'HELLO'
+      student.save!
+      student.reload
+
+      # Setting same raw input - setter transforms to same value
+      student.uppercase_name = 'hello'
+      assert_equal false, student.uppercase_name_changed?, 'Same value after setter transform should not mark dirty'
+      assert_equal false, student.changed?
+    end
+
+    def test_different_case_with_setter_proc_marks_dirty
+      student = Student.create(name: 'test_setter_diff')
+      student.uppercase_name = 'hello'  # Stored as 'HELLO'
+      student.save!
+      student.reload
+
+      # Setting different value
+      student.uppercase_name = 'world'  # Stored as 'WORLD'
+      assert_equal true, student.uppercase_name_changed?
+      assert_equal ['HELLO', 'WORLD'], student.uppercase_name_change
+    end
   end
 end


### PR DESCRIPTION
## 요약

- `serialized_property` setter에서 **동일한 값**으로 설정 시 불필요하게 dirty로 마킹되는 버그 수정
- 기존 값과 새 값을 비교하여, 실제로 값이 변경될 때만 `_will_change!` 호출

## 문제 현상

```ruby
device = BaseDevice.find(1)  # press_user_id: 123
device.press_user_id = 123   # 같은 값으로 설정
device.changed?              # => true (문제!)
device.save!                 # 불필요한 UPDATE 발생
```

## 수정 내용

- `_write_sprop_value` 메서드: `write_attribute`, `[]=` 호출 시 값 비교 로직 추가
- `_define_serialized_property` setter: 일반 setter 호출 시 값 비교 로직 추가

## 테스트

- 같은 값 설정 시 dirty 안됨
- 다른 값 설정 시 정상 dirty
- nil → 값, 값 → nil 변경 시 dirty
- nil → nil 설정 시 dirty 안됨
- `write_attribute`, `[]=` 접근자 테스트
- setter proc 적용 후 동일 값 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)